### PR TITLE
Fix some incorrect hrefs in documentation src

### DIFF
--- a/docs/src/documentation/entities.html
+++ b/docs/src/documentation/entities.html
@@ -44,8 +44,8 @@
 	<li><a href="entities/player.html">Player</a></li>
 	<p>
 		A very basic entity that serves as a wrapper for a
-		<a href="components/render.html">PlayerComponent</a> and a 
-		<a href="components/render.html">ControllerComponent</a>, which are
+		<a href="components/player.html">PlayerComponent</a> and a 
+		<a href="components/controller.html">ControllerComponent</a>, which are
 		connected together. Useful if you want the user of your application to
 		be able to walk around the scene.
 	</p>
@@ -59,7 +59,7 @@
 	<p>
 		It's meant for creating worldspawns.
 		<a href="components/render.html">RenderComponent</a> for the 3D model
-		part and <a href="components/render.html">PhysicsComponent</a> for the
+		part and <a href="components/physics.html">PhysicsComponent</a> for the
 		collision. Can add lightmaps.
 	</p>
 	<li><a href="entities/trigger.html">Trigger</a></li>

--- a/docs/src/documentation/physics.html
+++ b/docs/src/documentation/physics.html
@@ -18,7 +18,7 @@
 <p>
 	If you want to add rigidbodies to your entities, consider using the
 	<a href="components/physics.html">PhysicsComponent</a>. For triggers, the 
-	<a href="components/physics.html">TriggerComponent</a> is available.
+	<a href="components/trigger.html">TriggerComponent</a> is available.
 </p>
 
 <h2>

--- a/docs/src/learn/structure.html
+++ b/docs/src/learn/structure.html
@@ -69,7 +69,7 @@
 
 <p>
 	This directory contains the all of the
-	<a href="../documentation/framework/navmesh.html">Navhmeshes</a>.
+	<a href="../documentation/framework/navmesh.html">Navmeshes</a>.
 </p>
 
 <h4>


### PR DESCRIPTION
Hi there, thanks for making this awesome project!

I had a blast reading the documentation. Along the way I noticed two incorrect hrefs in `entities.html`, so I figured I'd make a PR. Then I made a crappy script that found some more, so I added those as well.

<details>
  <summary>Crappy script</summary>

```python
import glob


def split_by_uppercase(string):
    starts = [i for i, c in enumerate(string) if c.isupper()]
    ends = starts[1:] + [len(string)]
    return [string[start:end] for start, end in zip(starts, ends)]


def strip_plural(word):
    if word.endswith("es"):
        return word[:-2]
    if word.endswith("s"):
        return word[:-1]

    return word


def check_href_line(html_file, href_line, line_idx):
    target = href_line.split('<a href="')[1].split('">')[0]
    name = href_line.split('<a href="')[1].split('">')[1].split("<")[0]

    if name in ["Home", "Next", "Back"]:
        return

    if name.find(" ") != -1:
        return

    if not all([strip_plural(word).lower() in target for word in split_by_uppercase(name)]):
        print(f'Fishy href in {html_file} line {line_idx}: {href_line}\n    "{target}" , "{name}"')


def check_html(html_file):
    with open(html_file) as f:
        lines = f.readlines()

    href_lines_and_idxs = [(l.strip(), i + 1) for i, l in enumerate(lines) if "<a href=" in l]

    if not href_lines_and_idxs:
        return

    href_lines, idxs = zip(*href_lines_and_idxs)

    for href_line, line_idx in zip(href_lines, idxs):
        check_href_line(html_file, href_line, line_idx)


for html_file in glob.glob("*/*.html", recursive=True):
    check_html(html_file)

```
</details>

FWIW this is the kind of thing that the script outputs:

```
~/Documents/tram-sdk/docs/src$ python3 check_href.py 
Fishy href in documentation/components.html line 55: <a href="components/controller.html">CharacterController</a>.
    "components/controller.html" , "CharacterController"
```

Best regards and thanks for the func_door.

(Also I'm not sure why there's duplication of files in `docs` and `docs/src`, I figured the latter was unintended so I only applied the changes in the former)